### PR TITLE
記事投稿後の遷移先を変更

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -13,7 +13,7 @@ class ArticlesController < ApplicationController
     tag_names = params[:article][:tags][:name].split
     if Article.save_with_tags(current_user, tag_names, article_params)
       flash[:success] = '投稿が完了しました'
-      redirect_to root_url
+      redirect_to "/users/#{current_user.id}/articles"
     else
       render 'new'
     end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -15,6 +15,7 @@ module SessionsHelper
 
   def log_out
     session.delete(:user_id)
+    session[:forwarding_url] = nil
   end
 
   def redirect_back_or(default)


### PR DESCRIPTION
## やったこと
- 記事投稿後に記事一覧ページに遷移
- ログアウト時にフレンドリーフォワーディングをリセット