### PR TITLE
onloadが発火しない問題を解消

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -67,5 +67,10 @@
     document.getElementById("select-lists-button").style.display="inline";
     document.getElementById("button_for_display").style.display="none";
   }
-  window.onload = hide_form;
+  
+  if (document.readyState !== "loading") {
+    hide_form();
+  } else {
+    document.addEventListener("DOMContentLoaded", hide_form, false);
+  }
 </script>


### PR DESCRIPTION
## やったこと
- readyStateがloading以外のときはイベント発火を待たずにメソッド実行
