### PR TITLE
記事の文字数制限緩和

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,7 +8,7 @@ class Article < ApplicationRecord
   belongs_to :user
   validates :user_id, presence: true
   validates :title, presence: true, length: { maximum: 50 }
-  validates :body, presence: true, length: { maximum: 1000 }
+  validates :body, presence: true, length: { maximum: 10000 }
   validates :is_visible, inclusion: { in: [true, false] }
 
   def self.save_with_tags(current_user, tag_names, article_params)

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -31,7 +31,7 @@ class ArticleTest < ActiveSupport::TestCase
   end
 
   test "body should not be too long" do
-    @article.body = "a" * 1001
+    @article.body = "a" * 10001
     assert_not @article.valid?
   end
 


### PR DESCRIPTION
## やったこと
- 記事の文字数制限を1000から10000に変更